### PR TITLE
README: Update csvsoundsystem.com domain to csv.nyc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # csvsoundsystem.com
 
-The website for http://csvsoundsystem.com
+The website for http://csv.nyc
 


### PR DESCRIPTION
The http://csvsoundsystem.com URL in the README is pointing at a domain parking site; looks like it expired. This updates to the currently-live http://csv.nyc domain.